### PR TITLE
Fixes for Web Request and HTTP handler + Web Request Test Case

### DIFF
--- a/jsengine-android/jsengine/src/main/assets/webrequest.js
+++ b/jsengine-android/jsengine/src/main/assets/webrequest.js
@@ -29,18 +29,17 @@ var webRequest = {
           requestInfo.getRequestHeader = function(header) {
             return requestInfo.requestHeaders[header];
           };
-          var returnBlockingResponse = {};
-          this.listeners.forEach(function(listener) {
+          for (var i=0; i < this.listeners.length; i++) {
+            const listener = this.listeners[i];
             const fn = listener.fn;
             const filter = listener.filter;
             const extraInfo = listener.extraInfo;
             const blockingResponse = fn(requestInfo);
             if (blockingResponse && Object.keys(blockingResponse).length > 0) {
-                    returnBlockingResponse = blockingResponse;
-                    return;
+                return blockingResponse;
             }
-          });
-          return returnBlockingResponse;
+          }
+          return {};
         }
       },
 

--- a/jsengine-android/jsengine/src/main/assets/webrequest.js
+++ b/jsengine-android/jsengine/src/main/assets/webrequest.js
@@ -2,11 +2,11 @@
 var webRequest = {
     onBeforeRequest: {
         listeners: [],
-        addListener(listener, filter, extraInfo) {
-          this.listeners.push({fn: listener, filter, extraInfo});
+        addListener: function(listener, filter, extraInfo) {
+          this.listeners.push({fn: listener, filter: filter, extraInfo: extraInfo});
         },
-        removeListener(listener) {
-          const ind = this.listeners.findIndex((l) => {
+        removeListener: function(listener) {
+          const ind = this.listeners.findIndex(function(l) {
             return l.fn === listener;
           });
           if (ind > -1) {
@@ -14,7 +14,7 @@ var webRequest = {
           }
         },
 
-        _triggerJson(requestInfoJson) {
+        _triggerJson: function(requestInfoJson) {
           const requestInfo = JSON.parse(requestInfoJson);
           try {
               const response = webRequest.onBeforeRequest._trigger(requestInfo) || {};
@@ -24,29 +24,33 @@ var webRequest = {
           }
         },
 
-        _trigger(requestInfo) {
+        _trigger: function(requestInfo) {
           // getter for request headers
           requestInfo.getRequestHeader = function(header) {
             return requestInfo.requestHeaders[header];
           };
-          for (let listener of this.listeners) {
-              const {fn, filter, extraInfo} = listener;
-              const blockingResponse = fn(requestInfo);
-              if (blockingResponse && Object.keys(blockingResponse).length > 0) {
-                return blockingResponse;
-              }
-          }
-          return {};
+          var returnBlockingResponse = {};
+          this.listeners.forEach(function(listener) {
+            const fn = listener.fn;
+            const filter = listener.filter;
+            const extraInfo = listener.extraInfo;
+            const blockingResponse = fn(requestInfo);
+            if (blockingResponse && Object.keys(blockingResponse).length > 0) {
+                    returnBlockingResponse = blockingResponse;
+                    return;
+            }
+          });
+          return returnBlockingResponse;
         }
       },
 
       onBeforeSendHeaders: {
-        addListener(listener, filter, extraInfo) {},
-        removeListener(listener) {}
+        addListener: function(listener, filter, extraInfo) {},
+        removeListener: function(listener) {}
       },
 
       onHeadersReceived: {
-        addListener(listener, filter, extraInfo) {},
-        removeListener(listener) {}
+        addListener: function(listener, filter, extraInfo) {},
+        removeListener: function(listener) {}
       }
 }

--- a/jsengine-ios/jsengine.xcodeproj/project.pbxproj
+++ b/jsengine-ios/jsengine.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8602ECDD1E4B310300D6667C /* WebRequestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8602ECDC1E4B310300D6667C /* WebRequestTest.swift */; };
+		8602ECDE1E4B48BA00D6667C /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 865D9A141E291E3B00B82F81 /* assets */; };
 		860373B81E043C1200749750 /* ContentPolicyDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860373B41E043C1200749750 /* ContentPolicyDetector.swift */; };
 		860373B91E043C1200749750 /* InterceptorURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860373B51E043C1200749750 /* InterceptorURLProtocol.swift */; };
 		860373BA1E043C1200749750 /* WebRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860373B61E043C1200749750 /* WebRequest.swift */; };
@@ -77,6 +79,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8602ECDC1E4B310300D6667C /* WebRequestTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRequestTest.swift; sourceTree = "<group>"; };
 		860373B41E043C1200749750 /* ContentPolicyDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentPolicyDetector.swift; sourceTree = "<group>"; };
 		860373B51E043C1200749750 /* InterceptorURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptorURLProtocol.swift; sourceTree = "<group>"; };
 		860373B61E043C1200749750 /* WebRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRequest.swift; sourceTree = "<group>"; };
@@ -285,6 +288,7 @@
 				8665280C1E30FDB40044048E /* EngineTest.swift */,
 				8665280E1E310E810044048E /* AntiTrackingTest.swift */,
 				864134B31E3238490019683D /* AdblockerTest.swift */,
+				8602ECDC1E4B310300D6667C /* WebRequestTest.swift */,
 			);
 			path = jsengineTests;
 			sourceTree = "<group>";
@@ -523,6 +527,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8602ECDE1E4B48BA00D6667C /* assets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -588,6 +593,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8602ECDD1E4B310300D6667C /* WebRequestTest.swift in Sources */,
 				865D9A1C1E2E1E3E00B82F81 /* CryptoTest.swift in Sources */,
 				865D9A201E2E2E9100B82F81 /* FileIOTest.swift in Sources */,
 				865D9A221E2E57F900B82F81 /* HttpHandlerTest.swift in Sources */,

--- a/jsengine-ios/jsengine.xcodeproj/project.pbxproj
+++ b/jsengine-ios/jsengine.xcodeproj/project.pbxproj
@@ -14,9 +14,10 @@
 		860373BA1E043C1200749750 /* WebRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860373B61E043C1200749750 /* WebRequest.swift */; };
 		860373BE1E08169800749750 /* SystemLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860373BD1E08169800749750 /* SystemLoader.swift */; };
 		86173C151E1A7E1400015F5B /* PromiseCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86173C141E1A7E1400015F5B /* PromiseCallback.swift */; };
+		864134B41E3238490019683D /* AdblockerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864134B31E3238490019683D /* AdblockerTest.swift */; };
+		865B38301E5301E40065C3EA /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865B382F1E5301E40065C3EA /* Utils.swift */; };
 		865D9A151E291E3C00B82F81 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 865D9A141E291E3B00B82F81 /* assets */; };
 		865D9A161E291E6800B82F81 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 865D9A141E291E3B00B82F81 /* assets */; };
-		864134B41E3238490019683D /* AdblockerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864134B31E3238490019683D /* AdblockerTest.swift */; };
 		865D9A181E292C1000B82F81 /* AntiTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D9A171E292C1000B82F81 /* AntiTracking.swift */; };
 		865D9A1A1E2CCFAF00B82F81 /* Adblocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D9A191E2CCFAF00B82F81 /* Adblocker.swift */; };
 		865D9A1C1E2E1E3E00B82F81 /* CryptoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D9A1B1E2E1E3E00B82F81 /* CryptoTest.swift */; };
@@ -85,8 +86,9 @@
 		860373B61E043C1200749750 /* WebRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRequest.swift; sourceTree = "<group>"; };
 		860373BD1E08169800749750 /* SystemLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemLoader.swift; sourceTree = "<group>"; };
 		86173C141E1A7E1400015F5B /* PromiseCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseCallback.swift; sourceTree = "<group>"; };
-		865D9A141E291E3B00B82F81 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = "../../jsengine-android/jsengine/src/main/assets"; sourceTree = "<group>"; };
 		864134B31E3238490019683D /* AdblockerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdblockerTest.swift; sourceTree = "<group>"; };
+		865B382F1E5301E40065C3EA /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		865D9A141E291E3B00B82F81 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = "../../jsengine-android/jsengine/src/main/assets"; sourceTree = "<group>"; };
 		865D9A171E292C1000B82F81 /* AntiTracking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AntiTracking.swift; sourceTree = "<group>"; };
 		865D9A191E2CCFAF00B82F81 /* Adblocker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adblocker.swift; sourceTree = "<group>"; };
 		865D9A1B1E2E1E3E00B82F81 /* CryptoTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoTest.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 				B30042251DF86B92004F9E14 /* jsengineBridging-Header.h */,
 				86173C141E1A7E1400015F5B /* PromiseCallback.swift */,
 				86CF91591E26355800AAB46B /* DebugLogger.swift */,
+				865B382F1E5301E40065C3EA /* Utils.swift */,
 			);
 			path = jsengine;
 			sourceTree = "<group>";
@@ -578,6 +581,7 @@
 				86CF915A1E26355800AAB46B /* DebugLogger.swift in Sources */,
 				865D9A1A1E2CCFAF00B82F81 /* Adblocker.swift in Sources */,
 				860373BA1E043C1200749750 /* WebRequest.swift in Sources */,
+				865B38301E5301E40065C3EA /* Utils.swift in Sources */,
 				860373B91E043C1200749750 /* InterceptorURLProtocol.swift in Sources */,
 				B30042161DF867B5004F9E14 /* FileIO.swift in Sources */,
 				B30042241DF86B66004F9E14 /* WindowTimers.m in Sources */,

--- a/jsengine-ios/jsengine/Engine.swift
+++ b/jsengine-ios/jsengine/Engine.swift
@@ -45,8 +45,11 @@ public class Engine {
             self.fileIO!.extend(self.jsengine!)
             crypto.extend(self.jsengine!)
             self.http!.extend(self.jsengine!)
-            self.webRequest!.extend(self.jsengine!)
+            
+            
             self.systemLoader = SystemLoader(context: self.jsengine!, assetsRoot: "assets", buildRoot: "/build/modules/", bundle: bundle)
+            self.webRequest!.extend(self.jsengine!)
+            
         }
     }
     
@@ -65,6 +68,10 @@ public class Engine {
                     jsengine.evaluateScript("var __DEFAULTPREFS__ = \(defaultJSON!);")
                     try systemLoader.callFunctionOnModule("platform/startup", functionName: "startup")
                     self?.mIsRunning = true
+                    
+                    // Register the interceptor protocol after the engine finishing running
+                    // TODO: this step should be called after the AdBlocker finish loading otherwise it will block loading of websites visiting before loading finished
+                    NSURLProtocol.registerClass(InterceptorURLProtocol)
                 }
             } catch let error as NSError {
                 DebugLogger.log("<< Error while executing the startup function in the platform/startup module: \(error)")

--- a/jsengine-ios/jsengine/Engine.swift
+++ b/jsengine-ios/jsengine/Engine.swift
@@ -23,16 +23,18 @@ public class Engine {
     var webRequest: WebRequest?
     var systemLoader: SystemLoader?
     var mIsRunning: Bool = false
+    var bundle: NSBundle
 
     //MARK: - Singltone
     static let sharedInstance = Engine(bundle: NSBundle.mainBundle())
     
     //MARK: - Init
     public init(bundle: NSBundle) {
+        self.bundle = bundle
         self.fileIO = FileIO(queue:self.dispatchQueue)
         let crypto = Crypto()
         self.http = ChromeUrlHandler(queue: self.dispatchQueue, basePath: self.buildPath)
-        self.webRequest = WebRequest()
+        self.webRequest = WebRequest(bundle: bundle)
         
         dispatch_async(dispatchQueue) {
             self.jsengine = JSContext()
@@ -62,7 +64,7 @@ public class Engine {
         dispatch_async(dispatchQueue) {[weak self] in
             do {
                 if let jsengine = self?.jsengine ,let systemLoader = self?.systemLoader {
-                    let config = systemLoader.readSourceFile("cliqz", buildPath: "/build/config/", fileExtension: "json")
+                    let config = Utils.readSourceFile(self!.bundle, assetsRoot: "assets", assetPath: "cliqz", buildPath: "/build/config/", fileExtension: "json")
                     jsengine.evaluateScript("var __CONFIG__ = JSON.parse('\(config!)');")
                     let defaultJSON = self?.parseJSON(defaultPrefs!)
                     jsengine.evaluateScript("var __DEFAULTPREFS__ = \(defaultJSON!);")

--- a/jsengine-ios/jsengine/FileIO.swift
+++ b/jsengine-ios/jsengine/FileIO.swift
@@ -62,7 +62,7 @@ class FileIO {
             } else {
                 callback.callWithArguments([content])
             }
-        } catch let error as NSError {
+        } catch _ as NSError {
             // files does not exist, do no thing
             callback.callWithArguments(nil)
         }
@@ -70,11 +70,27 @@ class FileIO {
     
     func writeFile(path: String, data: String) {
         let p = self.documentDirectory
-        let filePathURL = NSURL(fileURLWithPath: p).URLByAppendingPathComponent(path)
-        do {
-            try data.writeToURL(filePathURL!, atomically: true, encoding: NSUTF8StringEncoding)
-        } catch let error as NSError {
-            print("WriteFile Failed: ---- \(error)")
+        if let filePathURL = NSURL(fileURLWithPath: p).URLByAppendingPathComponent(path) {
+            let containingDirectory = filePathURL.URLByDeletingLastPathComponent
+            createDirectoryIfNotExist(containingDirectory)
+            do {
+                try data.writeToURL(filePathURL, atomically: true, encoding: NSUTF8StringEncoding)
+            } catch let error as NSError {
+                print("WriteFile Failed: ---- \(error)")
+            }
+        }
+        
+    }
+    private func createDirectoryIfNotExist(directoryURL: NSURL?){
+        let fileManager = NSFileManager.defaultManager()
+        
+        if let path = directoryURL?.path where fileManager.fileExistsAtPath(path) == false {
+            do {
+                try fileManager.createDirectoryAtPath(path, withIntermediateDirectories: true, attributes: nil)
+            } catch let error as NSError {
+                //TODO log error here
+                NSLog("Could not create directory at path:\(path) because of the following error: \(error.debugDescription)")
+            }
         }
     }
     

--- a/jsengine-ios/jsengine/SystemLoader.swift
+++ b/jsengine-ios/jsengine/SystemLoader.swift
@@ -43,7 +43,9 @@ class SystemLoader {
         // some custom modules for the App: system and promise
         context.evaluateScript("System.set('system', { default: System });");
         context.evaluateScript("System.set('promise', { default: Promise });");
-
+        
+        // load webrequest
+        self.loadJavascriptSource("webrequest")
     }
     
     func readSourceFile(assetPath: String, buildPath: String, fileExtension: String) -> String? {

--- a/jsengine-ios/jsengine/SystemLoader.swift
+++ b/jsengine-ios/jsengine/SystemLoader.swift
@@ -43,21 +43,6 @@ class SystemLoader {
         // some custom modules for the App: system and promise
         context.evaluateScript("System.set('system', { default: System });");
         context.evaluateScript("System.set('promise', { default: Promise });");
-        
-        // load webrequest
-        self.loadJavascriptSource("webrequest")
-    }
-    
-    func readSourceFile(assetPath: String, buildPath: String, fileExtension: String) -> String? {
-        var content: String? = nil
-        let (sourceName, directory) = getSourceMetaData(assetPath, buildPath: buildPath)
-        if let path = self.bundle.pathForResource(sourceName, ofType: fileExtension, inDirectory: directory){
-            content = try? NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
-        } else {
-            DebugLogger.log("<< Script not found: \(assetPath)")
-            
-        }
-        return content
     }
     
     func loadModule(moduleName: String) throws -> JSValue {
@@ -107,7 +92,7 @@ class SystemLoader {
     }
     
     func loadSubScript(assetPath: String) {
-        if let content = readSourceFile(assetPath, buildPath: self.buildRoot, fileExtension: "js") {
+        if let content = Utils.readSourceFile(self.bundle, assetsRoot: self.assetsRoot, assetPath: assetPath, buildPath: self.buildRoot, fileExtension: "js") {
             self.jsContext?.evaluateScript(content)
         } else {
             DebugLogger.log("<< Could not load file: \(assetPath)")
@@ -115,45 +100,11 @@ class SystemLoader {
     }
     
     private func loadJavascriptSource(assetPath: String) {
-        if let content = readSourceFile(assetPath, buildPath: "", fileExtension: "js") {
+        if let content = Utils.readSourceFile(self.bundle, assetsRoot: self.assetsRoot, assetPath: assetPath, buildPath: "", fileExtension: "js") {
             self.jsContext?.evaluateScript(content)
         } else {
             DebugLogger.log("<< Could not load file: \(assetPath)")
         }
-    }
-    
-    private func getSourceMetaData(assetPath: String, buildPath: String) -> (String, String) {
-        var sourceName: String
-        var directory: String
-        // seperate the folder path and the file name of the asset
-        if assetPath.rangeOfString("/") != nil {
-            var pathComponents = assetPath.componentsSeparatedByString("/")
-            sourceName = pathComponents.last!
-            pathComponents.removeLast()
-            directory = self.assetsRoot + buildPath + pathComponents.joinWithSeparator("/")
-        } else {
-            sourceName = assetPath
-            directory = self.assetsRoot + buildPath
-        }
-        
-        // remove file extension
-        if SystemLoader.endsWith(sourceName, suffix:".js") {
-            sourceName = sourceName.stringByReplacingOccurrencesOfString(".js", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
-        }
-        
-        return (sourceName, directory)
-    }
-    
-    private static func endsWith(string: String, suffix: String) -> Bool {
-        // rangeOfString returns nil if other is empty, destroying the analogy with (ordered) sets.
-        if suffix.isEmpty {
-            return true
-        }
-        if let range = string.rangeOfString(suffix,
-                                          options: [NSStringCompareOptions.AnchoredSearch, NSStringCompareOptions.BackwardsSearch]) {
-            return range.endIndex == string.endIndex
-        }
-        return false
     }
 
 }

--- a/jsengine-ios/jsengine/Utils.swift
+++ b/jsengine-ios/jsengine/Utils.swift
@@ -1,0 +1,59 @@
+//
+//  Utils.swift
+//  jsengine
+//
+//  Created by Ghadir Eraisha on 2/14/17.
+//  Copyright © 2017 Cliqz GmbH. All rights reserved.
+//
+
+import Foundation
+
+class Utils {
+    
+    static func readSourceFile(bundle: NSBundle, assetsRoot: String, assetPath: String, buildPath: String, fileExtension: String) -> String? {
+        var content: String? = nil
+        let (sourceName, directory) = getSourceMetaData(assetsRoot, assetPath: assetPath, buildPath: buildPath)
+        if let path = bundle.pathForResource(sourceName, ofType: fileExtension, inDirectory: directory){
+            content = try? NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+        } else {
+            DebugLogger.log("<< Script not found: \(assetPath)")
+            
+        }
+        return content
+    }
+    
+    static func getSourceMetaData(assetsRoot: String, assetPath: String, buildPath: String) -> (String, String) {
+        var sourceName: String
+        var directory: String
+        // seperate the folder path and the file name of the asset
+        if assetPath.rangeOfString("/") != nil {
+            var pathComponents = assetPath.componentsSeparatedByString("/")
+            sourceName = pathComponents.last!
+            pathComponents.removeLast()
+            directory = assetsRoot + buildPath + pathComponents.joinWithSeparator("/")
+        } else {
+            sourceName = assetPath
+            directory = assetsRoot + buildPath
+        }
+        
+        // remove file extension
+        if endsWith(sourceName, suffix:".js") {
+            sourceName = sourceName.stringByReplacingOccurrencesOfString(".js", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
+        }
+        
+        return (sourceName, directory)
+    }
+    
+    static func endsWith(string: String, suffix: String) -> Bool {
+        // rangeOfString returns nil if other is empty, destroying the analogy with (ordered) sets.
+        if suffix.isEmpty {
+            return true
+        }
+        if let range = string.rangeOfString(suffix,
+                                            options: [NSStringCompareOptions.AnchoredSearch, NSStringCompareOptions.BackwardsSearch]) {
+            return range.endIndex == string.endIndex
+        }
+        return false
+    }
+
+}

--- a/jsengine-ios/jsengine/WebRequest.swift
+++ b/jsengine-ios/jsengine/WebRequest.swift
@@ -62,10 +62,9 @@ public class WebRequest {
     
     private func getBlockResponseForRequest(requestInfo: [String: AnyObject]) -> [NSObject : AnyObject]? {
 
-        if let requestInfoJsonString = toJSONString(requestInfo),
-            onBeforeRequest = self.webRequest?.valueForProperty("onBeforeRequest") {
+        if let onBeforeRequest = self.webRequest?.valueForProperty("onBeforeRequest") {
             
-            let blockResponse = onBeforeRequest.invokeMethod("_trigger", withArguments: [requestInfoJsonString])?.toDictionary()
+            let blockResponse = onBeforeRequest.invokeMethod("_trigger", withArguments: [requestInfo])?.toDictionary()
             
             return blockResponse
         }

--- a/jsengine-ios/jsengine/WebRequest.swift
+++ b/jsengine-ios/jsengine/WebRequest.swift
@@ -13,9 +13,10 @@ public class WebRequest {
     weak var jsContext: JSContext? = nil
     var tabs = NSMapTable.strongToWeakObjectsMapTable()
     var webRequest: JSValue?
+    var bundle: NSBundle
     
-    init() {
-        
+    init(bundle: NSBundle) {
+        self.bundle = bundle
     }
     
     func extend(context: JSContext) {
@@ -28,7 +29,14 @@ public class WebRequest {
         }
         context.setObject(unsafeBitCast(nativeIsWindowActive, AnyObject.self), forKeyedSubscript: "_nativeIsWindowActive")
         
-        self.webRequest = context.evaluateScript("webRequest")
+        if let content = Utils.readSourceFile(self.bundle, assetsRoot: "assets", assetPath: "webrequest", buildPath: "", fileExtension: "js") {
+            self.jsContext!.evaluateScript(content)
+        } else {
+            DebugLogger.log("<< Could not load file: webrequest.js")
+        }
+        
+        self.webRequest = self.jsContext?.evaluateScript("webRequest")
+
     }
     
     func shouldBlockRequest(request: NSURLRequest) -> Bool {

--- a/jsengine-ios/jsengine/WebRequest.swift
+++ b/jsengine-ios/jsengine/WebRequest.swift
@@ -60,7 +60,7 @@ public class WebRequest {
     
     //MARK: - Private Methods
     
-    private func getBlockResponseForRequest(requestInfo: [String: AnyObject]) -> [NSObject : AnyObject]? {
+    func getBlockResponseForRequest(requestInfo: [String: AnyObject]) -> [NSObject : AnyObject]? {
 
         if let onBeforeRequest = self.webRequest?.valueForProperty("onBeforeRequest") {
             

--- a/jsengine-ios/jsengineTests/WebRequestTest.swift
+++ b/jsengine-ios/jsengineTests/WebRequestTest.swift
@@ -1,0 +1,64 @@
+//
+//  WebRequestTest.swift
+//  jsengine
+//
+//  Created by Ghadir Eraisha on 2/8/17.
+//  Copyright © 2017 Cliqz GmbH. All rights reserved.
+//
+
+import XCTest
+import JavaScriptCore
+@testable import jsengine
+
+class WebRequestTest: XCTestCase {
+    
+    private var engine: Engine?
+    private var adb: Adblocker?
+    
+    override func setUp() {
+        super.setUp()
+        
+        self.engine = Engine(bundle: NSBundle(forClass: self.dynamicType))
+        self.adb = Adblocker(engine: self.engine!)
+        
+        let defaultPrefsAdblocker = Adblocker.getDefaultPrefs(true)
+        let defaultPrefsAttrack = AntiTracking.getDefaultPrefs(false)
+        
+        var defaultPrefs = [String: Bool]()
+        defaultPrefsAttrack.forEach { (k,v) in defaultPrefs[k] = v }
+        defaultPrefsAdblocker.forEach { (k,v) in defaultPrefs[k] = v as? Bool }
+        
+        self.engine?.startup(defaultPrefs)
+        
+        var adbModule: JSValue?
+        
+        while !(self.engine?.isRunning())! {
+            sleep(1)
+        }
+        do {
+        
+            adbModule = try self.engine?.systemLoader?.loadModule("adblocker/adblocker")
+            sleep(10)
+    
+        } catch _ {
+            print("Exception while Loading the Adblocker Module")
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testGetBlockResponseForRequest() {
+        
+        var requestDetails = [String: AnyObject]()
+        requestDetails["type"] = 2
+        requestDetails["method"] = "GET"
+        requestDetails["source"] = "http://www.bbc.com/"
+        requestDetails["url"] = "http://me-cdn.effectivemeasure.net/em.js"
+        
+        let blockResponse = self.engine?.webRequest!.getBlockResponseForRequest(requestDetails)
+        XCTAssertTrue(blockResponse!.count > 0)
+    }
+    
+}


### PR DESCRIPTION
@sam-cliqz @mahmoud-cliqz
1- Fixes for `HTTPhandler`: implemented a method that creates a directory in it doesn't exist while writing to a file.
2- Test case for blocking a web request after loading the Adblocker module.
3- Changes in the syntax of `webrequest.js` to solve the compatibility issues with `iOS 8, 9`. @sam-cliqz I hope it doesn't affect `Android`.
4- Minor changes in `WebRequest API` to solve problems with intercepting request.  